### PR TITLE
Event date no longer accepts day inputs if the month does not contain the day

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -345,8 +345,10 @@ Command: `create n/EVENT_NAME d/EVENT_DATE t/EVENT_TIME`
 
 - Event date has to be in the format `DD-MM-YYYY`.
     - DD represents the day (from 01-31 inclusive)
+      - A day will not be accepted if the month does not contain it.
+      - For example, February does not have a 29th day (unless it is a leap year) so `29-02-2021` will not be accepted.
     - MM represents the month (from 01-12 inclusive)
-    - YYYY represents the year
+    - YYYY represents the year.
 
 - Event time has to be in 24 hour time `HHMM`.
     - HH represents the hour (from 00-24 inclusive)

--- a/src/main/java/nustracker/model/event/EventDate.java
+++ b/src/main/java/nustracker/model/event/EventDate.java
@@ -6,6 +6,7 @@ import static nustracker.commons.util.AppUtil.checkArgument;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 
 /**
  * Represents an Event's Date.
@@ -13,9 +14,11 @@ import java.time.format.DateTimeParseException;
 public class EventDate {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "EventDates should be in the format DD-MM-YYYY. E.g. 09-10-2021.";
+            "EventDates should be in the format DD-MM-YYYY. E.g. 09-10-2021.\n"
+            + "Ensure that the month has that day. E.g. Feb only has 28 days (29 for leap years).";
 
-    private static final DateTimeFormatter INPUT_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy");
+    private static final DateTimeFormatter INPUT_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-uuuu")
+            .withResolverStyle(ResolverStyle.STRICT);
     private static final DateTimeFormatter OUTPUT_FORMATTER = DateTimeFormatter.ofPattern("MMM dd yyyy");
 
     public final LocalDate eventDate;

--- a/src/test/java/nustracker/model/event/EventDateTest.java
+++ b/src/test/java/nustracker/model/event/EventDateTest.java
@@ -33,10 +33,16 @@ class EventDateTest {
         Assertions.assertFalse(EventDate.isValidDate("32-10-2021")); // invalid day
         Assertions.assertFalse(EventDate.isValidDate("00-10-2021")); // invalid day
 
+        // month does not contain the day
+        Assertions.assertFalse(EventDate.isValidDate("29-02-2021"));
+        Assertions.assertFalse(EventDate.isValidDate("31-04-2021"));
+        Assertions.assertFalse(EventDate.isValidDate("31-06-2021"));
+
         // valid event dates
         Assertions.assertTrue(EventDate.isValidDate("09-10-2021")); // current date
         Assertions.assertTrue(EventDate.isValidDate("31-12-3000")); // late date
         Assertions.assertTrue(EventDate.isValidDate("01-01-1900")); // early date
+        Assertions.assertTrue(EventDate.isValidDate("29-02-2024")); // leap year
     }
 
 }


### PR DESCRIPTION
For example, 29-02-2021 will not be accepted as February does not have 29 days unless it's a leap year.

Closes #171 